### PR TITLE
docs: add link to angular-swa-auth library

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@
 - [Blazor Authentication for Azure Static Web Apps](https://github.com/Azure/azure-app-service-authentication)
 - [JavaScript API Authentication helper](https://github.com/aaronpowell/azure-static-web-apps-api-auth)
 - [React auth components](https://github.com/aaronpowell/react-static-web-apps-auth)
+- [Angular auth library](https://github.com/christianacca/static-web-apps-auth)
 
 ## Starter Kits
 


### PR DESCRIPTION
Hi guys, hope this is not too presumptuous... 

I've created a swa auth helper library for angular: https://www.npmjs.com/package/@christianacca/angular-swa-auth

It would be great to add a link to this library from here